### PR TITLE
remove unused metadata fields from query

### DIFF
--- a/functions/queries.ts
+++ b/functions/queries.ts
@@ -21,9 +21,7 @@ export const getApplicationsForExplorerQuery = gql`
         applicationsStartTime
         applicationsEndTime
         matchTokenAddress
-        roundMetadata
       }
-      metadata
       project: canonicalProject {
         tags
         id


### PR DESCRIPTION
removes application and round metadata fields from query, which to the best of my knowledge are unused fields that take up ~2/3 of a typical Indexer response. queries should be significantly smaller and potentially a bit faster.